### PR TITLE
Possible fix TID compression flag

### DIFF
--- a/Scarlet.IO.ImageFormats/Scarlet.IO.ImageFormats.csproj
+++ b/Scarlet.IO.ImageFormats/Scarlet.IO.ImageFormats.csproj
@@ -24,7 +24,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/Scarlet.IO.ImageFormats/Scarlet.IO.ImageFormats.csproj
+++ b/Scarlet.IO.ImageFormats/Scarlet.IO.ImageFormats.csproj
@@ -24,7 +24,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>


### PR DESCRIPTION
The compression flag for the format may be wrong. TID files from neptunia v2's GAME0000 GAME00000\event\bg\ has many TID files that has DXT5 compression fourcc, with the bit is not set.

The proposed fix is directly check for the compression fourcc. However, a string type is not a char[] as in c/c++. The current fix treats all fourccs with NULL start as non-compressed.

(I'm sorry if there's coding style error, etc. I simply do not know much about csharp...)